### PR TITLE
Add tzdata so TZ=Region/Foobar works

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -59,6 +59,7 @@ LABEL maintainer="CrazyMax" \
 RUN apk --update --no-cache add \
     ca-certificates \
     libressl \
+    tzdata \
   && rm -rf /tmp/* /var/cache/apk/*
 
 COPY --from=builder /app/swarm-cronjob /usr/local/bin/swarm-cronjob


### PR DESCRIPTION
As it stands adding `--env TZ=America/Chicago` currently doesn't work. Since many users want cron jobs to happen in our specific timezones without having to convert from UTC to local this is needed. This also fixes the documentation since you're already telling users to add the TZ environment variable.

```bash
$ docker run -it -e "TZ=America/Chicago" node:alpine sh
$ date
Mon May 11 14:58:11 UTC 2020
$ apk add tzdata
$ date
Mon May 11 09:58:20 CDT 2020
```

References: 
- https://github.com/gliderlabs/docker-alpine/issues/136
- https://www.grainger.xyz/timezone-in-docker-alpine-not-using-environment-variable-tz/