### PR TITLE
Add support for `replicated-job`

### DIFF
--- a/docs/usage/docker-labels.md
+++ b/docs/usage/docker-labels.md
@@ -3,10 +3,10 @@
 You can configure your service using swarm-cronjob through Docker labels:
 
 | Name                           | Default | Description                                                                                                        |
-|--------------------------------|---------|--------------------------------------------------------------------------------------------------------------------|
+| ------------------------------ | ------- | ------------------------------------------------------------------------------------------------------------------ |
 | `swarm.cronjob.enable`         |         | Set to true to enable the cronjob. **required**                                                                    |
 | `swarm.cronjob.schedule`       |         | [CRON expression format](https://godoc.org/github.com/robfig/cron#hdr-CRON_Expression_Format) to use. **required** |
 | `swarm.cronjob.skip-running`   | `false` | Do not start a job if the service is currently running.                                                            |
-| `swarm.cronjob.replicas`       | `1`     | Number of replicas to set on schedule in `replicated` mode.                                                        |
+| `swarm.cronjob.replicas`       | `1`     | Number of replicas to set on schedule in `replicated` mode, or `MaxConcurrent` limit in `replicated-job` mode.     |
 | `swarm.cronjob.registry-auth`  | `false` | Send registry authentication details to Swarm agents.                                                              |
 | `swarm.cronjob.query-registry` |         | Indicates whether the service update requires contacting a registry                                                |

--- a/internal/docker/service.go
+++ b/internal/docker/service.go
@@ -84,10 +84,14 @@ func (c *DockerClient) ServiceList(args *model.ServiceListArgs) ([]*model.Servic
 		if service.UpdateStatus != nil {
 			res[i].UpdateStatus = string(service.UpdateStatus.State)
 		}
-		if service.Spec.Mode.Replicated != nil && service.Spec.Mode.Replicated.Replicas != nil {
+		switch {
+		case service.Spec.Mode.Replicated != nil && service.Spec.Mode.Replicated.Replicas != nil:
 			res[i].Mode = model.ServiceModeReplicated
 			res[i].Replicas = *service.Spec.Mode.Replicated.Replicas
-		} else if service.Spec.Mode.Global != nil {
+		case service.Spec.Mode.ReplicatedJob != nil:
+			res[i].Mode = model.ServiceModeReplicatedJob
+			res[i].Replicas = *service.Spec.Mode.ReplicatedJob.MaxConcurrent
+		case service.Spec.Mode.Global != nil:
 			res[i].Mode = model.ServiceModeGlobal
 			res[i].Replicas = tasksNoShutdown[service.ID]
 		}

--- a/internal/model/docker.go
+++ b/internal/model/docker.go
@@ -41,8 +41,9 @@ type ServiceMode string
 
 // Services modes available
 const (
-	ServiceModeReplicated = ServiceMode("replicated")
-	ServiceModeGlobal     = ServiceMode("global")
+	ServiceModeReplicated    = ServiceMode("replicated")
+	ServiceModeReplicatedJob = ServiceMode("replicated-job")
+	ServiceModeGlobal        = ServiceMode("global")
 )
 
 // TaskInfo represents attributes of a task

--- a/test/replicated-job-basic.yml
+++ b/test/replicated-job-basic.yml
@@ -1,0 +1,16 @@
+version: "3.8"
+
+services:
+  test:
+    image: busybox
+    command: ["sh", "-c", "echo 'Basic replicated job executed at:' && date"]
+    deploy:
+      mode: replicated-job
+      replicas: 0
+      labels:
+        - "swarm.cronjob.enable=true"
+        - "swarm.cronjob.schedule=0/30 * * * * *"
+        - "swarm.cronjob.skip-running=false"
+        - "swarm.cronjob.replicas=1"
+      restart_policy:
+        condition: none


### PR DESCRIPTION
This PR adds support for `replicated-job` Services, which was pretty straight forward to add.

Sadly, the `global-job` concept of Docker Swarm is impossible to integrate into `swarm-cronjob` as it stands today. There's no way to have a `global-job` Service that doesn't start tasks immediately when created and can be updated on-demand to trigger the job.