### PR TITLE
worker: skip cron runs while services are reconciling

### DIFF
--- a/internal/docker/service.go
+++ b/internal/docker/service.go
@@ -79,6 +79,7 @@ func (c *DockerClient) ServiceList(args *model.ServiceListArgs) ([]*model.Servic
 			Image:     normalizeImage(service.Spec.TaskTemplate.ContainerSpec.Image),
 			Labels:    service.Spec.Labels,
 			Actives:   running[service.ID],
+			Busy:      tasksNoShutdown[service.ID],
 			UpdatedAt: service.UpdatedAt.Local(),
 			Rollback:  service.PreviousSpec != nil,
 		}

--- a/internal/docker/service_test.go
+++ b/internal/docker/service_test.go
@@ -168,6 +168,7 @@ func TestServiceList(t *testing.T) {
 	require.Equal(t, model.ServiceModeReplicated, replicatedService.Mode)
 	require.EqualValues(t, 3, replicatedService.Replicas)
 	require.EqualValues(t, 1, replicatedService.Actives)
+	require.EqualValues(t, 2, replicatedService.Busy)
 	require.True(t, replicatedService.Rollback)
 	require.Equal(t, string(swarm.UpdateStateCompleted), replicatedService.UpdateStatus)
 	require.Equal(t, updatedAt.Local(), replicatedService.UpdatedAt)
@@ -178,6 +179,7 @@ func TestServiceList(t *testing.T) {
 	require.Equal(t, model.ServiceModeGlobal, globalService.Mode)
 	require.EqualValues(t, 1, globalService.Replicas)
 	require.EqualValues(t, 1, globalService.Actives)
+	require.EqualValues(t, 1, globalService.Busy)
 	require.False(t, globalService.Rollback)
 	require.Empty(t, globalService.UpdateStatus)
 }

--- a/internal/model/docker.go
+++ b/internal/model/docker.go
@@ -30,6 +30,7 @@ type ServiceInfo struct {
 	Mode         ServiceMode
 	Labels       map[string]string
 	Actives      uint64
+	Busy         uint64
 	Replicas     uint64
 	Rollback     bool
 	UpdatedAt    time.Time

--- a/internal/worker/worker.go
+++ b/internal/worker/worker.go
@@ -46,9 +46,18 @@ func (c *Client) Run() {
 			Msg("Skip running job")
 		return
 	}
+	if c.Job.SkipRunning && service.Busy > 0 {
+		log.Warn().Str("service", c.Job.Name).
+			Uint64("tasks_active", service.Actives).
+			Uint64("tasks_busy", service.Busy).
+			Str("status", service.UpdateStatus).
+			Msg("Skip busy job")
+		return
+	}
 
 	log.Info().Str("service", c.Job.Name).
 		Uint64("tasks_active", service.Actives).
+		Uint64("tasks_busy", service.Busy).
 		Str("status", service.UpdateStatus).Msg("Start job")
 
 	// Set number of replicas in replicated mode

--- a/internal/worker/worker_test.go
+++ b/internal/worker/worker_test.go
@@ -89,7 +89,35 @@ func TestRunSkipsUpdateWhenJobIsAlreadyActive(t *testing.T) {
 			{
 				Name:    "backup",
 				Actives: 2,
+				Busy:    2,
 				Raw:     replicatedService("svc-1", "backup", 7, 1, "busybox:latest"),
+			},
+		},
+	}
+
+	client := Client{
+		Docker: stub,
+		Job: model.Job{
+			Name:        "backup",
+			SkipRunning: true,
+			Replicas:    1,
+		},
+	}
+
+	client.Run()
+
+	require.Empty(t, stub.updateCalls)
+	require.Zero(t, stub.authCalls)
+}
+
+func TestRunSkipsUpdateWhenJobIsBusyButNotYetRunning(t *testing.T) {
+	stub := &workerDockerStub{
+		serviceResponses: []*model.ServiceInfo{
+			{
+				Name:         "backup",
+				Busy:         1,
+				UpdateStatus: string(swarm.UpdateStateUpdating),
+				Raw:          replicatedService("svc-1", "backup", 7, 1, "busybox:latest"),
 			},
 		},
 	}


### PR DESCRIPTION
fixes https://github.com/crazy-max/swarm-cronjob/issues/423

The service inspection path now records a busy task count based on non-shutdown tasks, and the worker now treats that state as busy when `swarm.cronjob.skip-running=true`. This keeps the existing behavior for active running tasks and extends it to services that are still reconciling during an update.