### PR TITLE
fix: scale replicated cron services back to 0 after cron runs

### DIFF
--- a/internal/worker/worker.go
+++ b/internal/worker/worker.go
@@ -2,6 +2,7 @@ package worker
 
 import (
 	"context"
+	"time"
 
 	"github.com/crazy-max/swarm-cronjob/internal/docker"
 	"github.com/crazy-max/swarm-cronjob/internal/model"
@@ -100,6 +101,38 @@ func (c *Client) Run() {
 	}
 	for _, warn := range response.Warnings {
 		log.Warn().Str("service", c.Job.Name).Msg(warn)
+	}
+}
+
+func (c *Client) waitForRunCompletionAndScaleDown() error {
+	ctx, cancel := context.WithTimeout(context.Background(), waitForCompletionTimeout)
+	defer cancel()
+
+	ticker := time.NewTicker(waitForCompletionPollInterval)
+	defer ticker.Stop()
+
+	seenRunning := false
+
+	for {
+		service, err := c.Docker.Service(c.Job.Name)
+		if err != nil {
+			return err
+		}
+
+		if service.Actives > 0 || service.Busy > 0 {
+			seenRunning = true
+		}
+
+		if seenRunning && service.Actives == 0 && service.Busy == 0 {
+			_, err := c.scaleDown(service.Raw)
+			return err
+		}
+
+		select {
+		case <-ctx.Done():
+			return ctx.Err()
+		case <-ticker.C:
+		}
 	}
 }
 

--- a/internal/worker/worker_test.go
+++ b/internal/worker/worker_test.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"errors"
 	"testing"
+	"time"
 
 	"github.com/crazy-max/swarm-cronjob/internal/model"
 	"github.com/moby/moby/api/types/events"
@@ -177,6 +178,65 @@ func TestRunScalesDownReplicatedServiceBeforeUpdating(t *testing.T) {
 	require.NotContains(t, finalUpdate.labels, "swarm.cronjob.scaledown")
 	require.EqualValues(t, 8, finalUpdate.force)
 	require.Equal(t, swarm.RegistryAuthFromSpec, finalUpdate.options.RegistryAuthFrom)
+}
+
+func TestRunScalesBackToZeroWhenServiceStartedFromZero(t *testing.T) {
+	oldPoll := waitForCompletionPollInterval
+	oldTimeout := waitForCompletionTimeout
+	waitForCompletionPollInterval = time.Millisecond
+	waitForCompletionTimeout = 100 * time.Millisecond
+	defer func() {
+		waitForCompletionPollInterval = oldPoll
+		waitForCompletionTimeout = oldTimeout
+	}()
+
+	stub := &workerDockerStub{
+		serviceResponses: []*model.ServiceInfo{
+			{
+				Name: "backup",
+				Mode: model.ServiceModeReplicated,
+				Raw:  replicatedService("svc-1", "backup", 7, 0, "busybox:latest"),
+			},
+			{
+				Name:    "backup",
+				Mode:    model.ServiceModeReplicated,
+				Actives: 1,
+				Busy:    1,
+				Raw:     replicatedService("svc-1", "backup", 8, 1, "busybox:latest"),
+			},
+			{
+				Name: "backup",
+				Mode: model.ServiceModeReplicated,
+				Raw:  replicatedService("svc-1", "backup", 8, 1, "busybox:latest"),
+			},
+			{
+				Name: "backup",
+				Mode: model.ServiceModeReplicated,
+				Raw:  replicatedService("svc-1", "backup", 9, 0, "busybox:latest"),
+			},
+		},
+	}
+
+	client := Client{
+		Docker: stub,
+		Job: model.Job{
+			Name:     "backup",
+			Replicas: 1,
+		},
+	}
+
+	client.Run()
+
+	require.Len(t, stub.updateCalls, 2)
+
+	startUpdate := stub.updateCalls[0]
+	require.NotNil(t, startUpdate.replicas)
+	require.EqualValues(t, 1, *startUpdate.replicas)
+
+	restoreUpdate := stub.updateCalls[1]
+	require.NotNil(t, restoreUpdate.replicas)
+	require.Zero(t, *restoreUpdate.replicas)
+	require.Equal(t, "true", restoreUpdate.labels["swarm.cronjob.scaledown"])
 }
 
 func TestRunUsesRegistryAuthAndQueryRegistryFlags(t *testing.T) {


### PR DESCRIPTION
This change fixes the lifecycle of one-shot replicated services started by swarm-cronjob.

Previously, services that were intentionally deployed with replicas: 0 to remain idle until their cron schedule fired were scaled up by swarm-cronjob for execution, but then left at the scheduled replica count afterward, typically 1. As a result, the service no longer returned to its intended idle state after the job had finished.

This patch changes that behavior for replicated services that started from 0 replicas: after the scheduled run completes, swarm-cronjob now scales the service back down to 0.